### PR TITLE
fixing udp proxy and config

### DIFF
--- a/.ncmpcpp/config
+++ b/.ncmpcpp/config
@@ -1,10 +1,9 @@
 # See: http://git.musicpd.org/cgit/mirror/ncmpcpp.git/tree/doc/config
-#
+
 visualizer_fifo_path = "/tmp/mpd.fifo"
-#visualizer_output_name = "Mute"
+visualizer_output_name = "my_fifo"
 visualizer_sync_interval = "30"
 visualizer_in_stereo = "yes"
-#visualizer_type = "wave" (spectrum/wave)
-visualizer_type = "spectrum" (spectrum/wave)
-#visualizer_look = "◆│"  # “diamond character” and “box-drawing character”
-#visualizer_color = "blue"
+visualizer_type = "wave"
+visualizer_look = "+|"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,3 +23,5 @@ RUN chown -R ncmpcpp /home/ncmpcpp/.ncmpcpp
 USER ncmpcpp
 
 ENTRYPOINT ["/ncmpcpp.sh"]
+CMD ["/usr/bin/ncmpcpp"]
+

--- a/ncmpcpp.sh
+++ b/ncmpcpp.sh
@@ -1,17 +1,13 @@
 #!/bin/sh
 
-udp_fifo() {
-  # Start listening to UDP on port 5555 and create a FIFO queue out of it,
-  # used for visualization. See https://github.com/mopidy/mopidy/issues/775
-  mkfifo /tmp/mpd.fifo
-  while :
-  do
-    nc -kluw 1 0.0.0.0 5555 >/tmp/mpd.fifo 2>/dev/null
-    sleep 3
-  done
+mkfifo /tmp/mpd.fifo || true
+
+udpsink(){
+  setsid nc -kluw 1 127.0.0.1 5555 > /tmp/mpd.fifo 2> /dev/null
 }
 
-udp_fifo &
+udpsink &
 
-# Start actual ncmpcpp
-exec ncmpcpp $*
+
+exec "$@"
+


### PR DESCRIPTION
- missing visualizer name
- daemonized udp proxy to fifo

in conjunction with this pr https://github.com/wernight/docker-mopidy/pull/15 It should fix the udp sink and visualizations should work